### PR TITLE
chore: add basic Codespaces devcontainer for PHP

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "PHP Dev",
+  "image": "mcr.microsoft.com/devcontainers/php:8.2",
+  "postCreateCommand": "composer install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "xdebug.php-debug"
+      ]
+    }
+  },
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "PHP Server",
+      "onAutoForward": "openPreview"
+    }
+  }
+}


### PR DESCRIPTION
- Added .devcontainer/devcontainer.json with PHP 8.2 base image
- Installed Composer automatically
- Preinstalled VS Code extensions for PHP IntelliSense and Xdebug
- Forwarded port 8080 for running local PHP server